### PR TITLE
Revise `git archive` documentation for clarity

### DIFF
--- a/notes/11_archive.md
+++ b/notes/11_archive.md
@@ -1,10 +1,6 @@
 ## Git Archive
 
-`git archive` is a command for creating compressed archives of a repository’s tracked files at a specific point in time. It’s a quick way to package your project’s current state without including Git’s version history or untracked files. The result is a clean, self-contained snapshot you can share, back up, or deploy.
-
-Unlike copying a project folder manually, `git archive` ensures the archive contains only what Git tracks—no `.git` directory, no local build artifacts, and no accidental temporary files.
-
-For example, say you’re working on a software project and need to send the latest stable version to a collaborator. You don’t want to send your full Git history or other unrelated files—just the working files from a specific commit. `git archive` does exactly that, packaging them neatly into formats like `tar` or `zip`.
+`git archive` is your clean-room packager. It snapshots exactly what Git tracks at a commit—no `.git` folder, no stray build junk, no temp files—so you can hand someone a tidy source bundle or ship code to a server without dragging history along. Think of it as a camera: you point it at a commit, click, and get a tar/zip of only the files that belong in that picture. It’s great for releases, vendor handoffs, monorepo subtrees, and “just give me the code” moments. Because the archive is created from the repository’s tree, not your working directory, it’s consistent and repeatable, which makes ops and audits much happier.
 
 ```
 +------------------------+                   +------------------------+
@@ -16,43 +12,49 @@ For example, say you’re working on a software project and need to send the lat
 +------------------------+                   +------------------------+
 ```
 
-The left box is your Git repository, including `.git` (history/metadata) and working files. The right box is the resulting archive—`.git` is gone, leaving only the project files you want.
+The left box is your repo with history + working files; the right box is the clean export—no `.git`, only tracked content as of the chosen commit.
 
-### Creating Archives for a Snapshot of the Repository
+### Quick snapshots (branch, tag, or commit)
 
-You can archive files from a specific commit, branch, or tag. The `.git` directory and untracked files are excluded automatically, so the archive stays clean.
-
-Example: create a `zip` archive of the latest commit on the current branch:
+You pick a point in time (HEAD, a branch, a tag, a SHA), and you get a bundle. This is the “just give me today’s code” path.
 
 ```bash
-git archive -o archive_name.zip HEAD
+# Zip of whatever you're on now
+git archive -o project.zip HEAD
+
+# Tar.gz from a release tag, with a friendly top-level folder name
+git archive --format=tar --prefix=project-1.4.2/ v1.4.2 | gzip > project-1.4.2.tar.gz
+
+# Peek inside without extracting
+tar -tzf project-1.4.2.tar.gz | head
+# output (example):
+# project-1.4.2/
+# project-1.4.2/README.md
+# project-1.4.2/src/main.py
+# project-1.4.2/src/utils/__init__.py
 ```
 
-Here:
+A tiny mental model:
 
-* `HEAD` means “current commit of the current branch.”
-* You can replace `HEAD` with a branch name, tag, or commit hash to target a different point in history.
-
-By default, `git archive` writes to standard output (stdout). This lets you pipe it directly to another process—like compressing with `gzip` or sending over SSH—without creating a file first:
-
-```bash
-git archive branch_name | gzip | ssh user@host "cat > project.tar.gz"
+```
+commit (tree) ──► reproducible source package
+      ^
+      └── HEAD / tag / SHA you chose
 ```
 
-This:
+### Partial exports
 
-1. Creates an archive of `branch_name`.
-2. Compresses it with `gzip`.
-3. Streams it straight to a remote server.
-
-### Exporting Specific Files or Directories
-
-If you only need part of a repository, `git archive` can target individual files or folders.
-
-Example: archive only `config.yml` from the current commit:
+You don’t have to ship the whole repo. Target a file, a folder, or a pattern and keep the archive lean.
 
 ```bash
+# One file from HEAD
 git archive -o config.zip HEAD config.yml
+
+# One directory
+git archive -o api.zip HEAD services/api/
+
+# Glob patterns (quote so your shell doesn’t expand it)
+git archive -o py-src.zip HEAD ':(glob)src/**/*.py'
 ```
 
 Visualization:
@@ -65,19 +67,13 @@ Visualization:
 +------------------------+                     +-----------------------+
 ```
 
-The resulting archive contains only `config.yml` as it exists in that commit. The same works for directories—just provide the path.
+### Prefixes that keep things organized
 
----
-
-### Customizing the Archive with Prefixes and Filters
-
-You can add a path prefix to every file in the archive. This is useful for avoiding filename collisions or preparing files for deployment into a subfolder.
+A prefix puts everything under a single folder inside the archive—super handy for releases and avoiding file collisions when someone extracts.
 
 ```bash
 git archive --prefix=project-name/ -o project.zip HEAD
 ```
-
-Visualization:
 
 ```
 +------------------------+                   +------------------------------+
@@ -89,55 +85,106 @@ Visualization:
 +------------------------+                   +------------------------------+
 ```
 
-You can also filter which files are included using patterns. For example, to archive only Python files from a specific folder:
+### Stream it (no temp files, even to another box)
+
+Because `git archive` writes to stdout by default, you can compress and ship in one go. Great for deployments or quick backups.
 
 ```bash
-git archive -o source_code.zip HEAD -- path/to/code/*.py
+git archive main | gzip | ssh user@host "cat > /deploy/project-$(date +%F).tar.gz"
+# output (local):
+# (no local file created; archive landed on remote host)
 ```
 
-Visualization:
+Remote server view:
 
 ```
-+------------------------+     git archive     +-----------------------+
-|      BRANCH HEAD       |    ============>    | python_files.zip      |
-| src/   file1.py        |                     | src/   file1.py       |
-| lib/   helper.py       |                     | lib/   helper.py      |
-| docs/  guide.txt       |                     |                       |
-+------------------------+                     +-----------------------+
+[repo @ dev box] --stdout--> [gzip] --ssh--> [/deploy/project-2025-09-13.tar.gz]
 ```
 
-### Supported Formats for Archiving
+### Real-world flows that come up all the time
 
-By default, `git archive` produces `tar` files, but you can request other formats:
-
-| Format   | Description             | Example Output   |
-| -------- | ----------------------- | ---------------- |
-| `tar`    | Uncompressed tarball    | `project.tar`    |
-| `tar.gz` | Gzip-compressed tarball | `project.tar.gz` |
-| `zip`    | Zip-compressed archive  | `project.zip`    |
-
-The format can be set explicitly with `--format` or inferred from the file extension in `-o`.
-
-### Example Workflow: Deployment
-
-You want to deploy the latest `main` branch to a server:
-
-I. Create a tar archive of `main`:
+**1) Release tarball from a tag, nice folder name inside**
 
 ```bash
-git archive --format=tar main > project.tar
+git archive --format=tar --prefix=myapp-2.0.0/ v2.0.0 | gzip > myapp-2.0.0.tar.gz
 ```
 
-II. Compress it:
+**2) Monorepo: ship just one service**
 
 ```bash
-gzip project.tar
+git archive -o payments.zip HEAD services/payments/
 ```
 
-III. Transfer it to the server:
+**3) Vendor handoff: exclude dev-only stuff using `.gitattributes`**
+Create rules once, every archive stays clean.
 
 ```bash
+# .gitattributes (commit this)
+docs/private/**    export-ignore
+*.psd              export-ignore
+scripts/dev/**     export-ignore
+VERSION            export-subst
+```
+
+And if `VERSION` contains a placeholder, it gets filled when you archive:
+
+```text
+# VERSION file in repo
+MyApp $Format:%h$ ($Format:%ci$)
+```
+
+```bash
+git archive -o clean.zip HEAD
+# After extracting clean.zip, VERSION might read:
+# MyApp 9f3a1c2 (2025-09-13 09:45:12 +0000)
+```
+
+**4) Zero-clone archive from a remote (server does the packing)**
+Useful when you don’t want a local checkout.
+
+```bash
+git archive --remote=ssh://git@yourserver/opt/git/myrepo.git v1.4.2 | gzip > myrepo-1.4.2.tar.gz
+# note: the remote must allow git-upload-archive over SSH
+```
+
+### Formats you’ll actually use
+
+* `tar` → `project.tar` (uncompressed, fast on server-to-server)
+* `tar.gz` → `project.tar.gz` (common for releases)
+* `zip` → `project.zip` (nice for Windows users)
+
+Pick explicitly, or let `-o`’s extension do the talking:
+
+```bash
+git archive --format=zip -o src.zip HEAD
+git archive --format=tar HEAD > project.tar
+```
+
+### Deployment example, end-to-end
+
+You want the latest `main` on a server, clean and quick.
+
+```bash
+# I. create tar from main and compress
+git archive --format=tar main | gzip > project.tar.gz
+
+# II. ship it
 scp project.tar.gz user@server:/deployments
+
+# III. unpack on the server
+ssh user@server 'mkdir -p /apps/project && tar -xzf /deployments/project.tar.gz -C /apps/project'
 ```
 
-Result: the server gets a compact package with only the files it needs, ready to extract and use.
+Result: server gets only the tracked sources, with the exact tree from `main`.
+
+### Sanity checks and small gotchas
+
+```bash
+# List contents of a tar.gz without extracting
+tar -tzf project.tar.gz | sed -n '1,10p'
+```
+
+* Untracked or ignored files are not included. If you rely on built assets, either track them (not ideal) or build on the target machine after extracting.
+* Submodules aren’t pulled in automatically; they appear as empty directories in archives. Package them separately or run a build step that fetches their sources.
+* Remote archiving depends on the server allowing `git-upload-archive` over SSH; most self-hosted setups do, some hosted platforms disable it.
+* Executable bits are preserved; extended attributes aren’t. If permissions matter in production, set them in your deploy scripts.


### PR DESCRIPTION
Updated the explanation of `git archive` to clarify its functionality and usage examples, including details on creating archives, filtering files, and supported formats.